### PR TITLE
patch Update parser.cpp

### DIFF
--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -217,10 +217,10 @@ void GCodeParser::parse(char *p) {
 
     #if ENABLED(GCODE_MOTION_MODES)
       #if ENABLED(ARC_SUPPORT)
-        case 'I' ... 'J': case 'R':
+        case 'I' ... 'J': 
           if (motion_mode_codenum != 2 && motion_mode_codenum != 3) return;
       #endif
-      case 'P' ... 'Q':
+      case 'Q':
         if (motion_mode_codenum != 5) return;
       case 'X' ... 'Z': case 'E' ... 'F':
         if (motion_mode_codenum < 0) return;
@@ -231,8 +231,37 @@ void GCodeParser::parse(char *p) {
       break;
     #endif // GCODE_MOTION_MODES
 
+    case 'R': {
+      #if ENABLED(GCODE_MOTION_MODES)
+        #if ENABLED(ARC_SUPPORT)
+          if (motion_mode_codenum != 2 && motion_mode_codenum != 3) return;
+        #endif
+      #endif
+      #if ENABLED(REALTIME_REPORTING_COMMANDS)
+        codenum = 0;                  // The only valid codenum is 0
+        uint8_t digits = 0;
+        while (*p++ == '0') digits++; // Count up '0' characters
+        command_letter = (digits == 3) ? letter : '?'; // Three '0' digits is a good command
+        return;
+      #endif
+    }
+
+    case 'P': {
+      #if ENABLED(GCODE_MOTION_MODES)
+        if (motion_mode_codenum != 5) return;
+      #endif
+      #if ENABLED(REALTIME_REPORTING_COMMANDS)
+        codenum = 0;                  // The only valid codenum is 0
+        uint8_t digits = 0;
+        while (*p++ == '0') digits++; // Count up '0' characters
+        command_letter = (digits == 3) ? letter : '?'; // Three '0' digits is a good command
+        return;
+      #endif
+      
+    }
+
     #if ENABLED(REALTIME_REPORTING_COMMANDS)
-      case 'S': case 'P': case 'R': {
+      case 'S': {
         codenum = 0;                  // The only valid codenum is 0
         uint8_t digits = 0;
         while (*p++ == '0') digits++; // Count up '0' characters


### PR DESCRIPTION
on compile generates error when REALTIME_REPORTING_COMMANDS feature is enabled. R,and P cases are defined twice when  GCODE_MOTION_MODES is enabled.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
 Can't compile when GCODE_MOTION_MODES and REALTIME_REPORTING_COMMANDS are enabled.
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
Is quick fix to allow the parser understand command is ok.
<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

#21629
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
